### PR TITLE
Correzione del nome di Università degli Studi del Salento.

### DIFF
--- a/radar/radar.js
+++ b/radar/radar.js
@@ -251,7 +251,7 @@ var universities = [
 		"value": "uni:foggia"
 	},
 	{
-		"label": "Università degli Studi del Salento",
+		"label": "Università del Salento - Lecce",
 		"value": "uni:salento"
 	},
 	{


### PR DESCRIPTION
Il nome ufficiale è proprio "Università del Salento". Aggiunta anche la provincia (Lecce) separata dal trattino.

Rif. http://www.unisalento.it
