### PR TITLE
Milano UnixMiB: promossa a sezione locale

### DIFF
--- a/db/lombardia.txt
+++ b/db/lombardia.txt
@@ -8,7 +8,7 @@ Milano|ILS Novate Milanese|Novate Milanese|https://www.ils.org/sezionilocali/nov
 Milano|LUG Legnano|Legnano|http://luglegnano.wordpress.com/|gnevav83@tznvy.pbz
 Milano|PCOfficina|Milano|http://www.pcofficina.org/|oynpxqbbz.jvsv@tznvy.pbz|2098656822
 Milano|POuL|Milano|http://www.poul.org/|qnavryrvnznegvab@tznvy.pbz
-Milano|unixMiB|Milano, Universit&agrave; Bicocca|https://unixmib.org/|havkzvo@tznvy.pbz
+Milano|ILS Milano|Milano|https://www.ils.org/sezionilocali/milano/|havkzvo@tznvy.pbz
 Monza e Brianza|VimeLUG|Vimercate|http://www.vimelug.org/|nqzg@ivzryht.bet
 Pavia|NutriaLUG|Pavia|https://www.facebook.com/groups/nutria.lug/|ahgevn.yht@tznvy.pbz
 Varese|GULLP - Gruppo Utenti Linux Lonate Pozzolo|Provincia di Varese sud / Malpensa|http://www.gullp.it/|yhpn.crerapva@tznvy.pbz


### PR DESCRIPTION
Ho tentato di rendere Milano una sezione locale (se ho capito correttamente basta aggiungere "ILS" nel nome).

Non testato.

Fonte:

https://www.ils.org/sezionilocali/